### PR TITLE
修复 IPv6 DNS 回退规则

### DIFF
--- a/boxctl/src/logger.rs
+++ b/boxctl/src/logger.rs
@@ -89,6 +89,7 @@ pub enum LogKey {
     FamilyRuleFailed,
     FamilyRulesSkipped,
     Ip6NatUnavailable,
+    Ipv6DnsFallbackApplied,
     CoreBypassFallback,
     PerformanceAddrtypeFallback,
     DnsCoreBypassFailed,

--- a/boxctl/src/logger/catalog.rs
+++ b/boxctl/src/logger/catalog.rs
@@ -69,6 +69,9 @@ fn en_template(key: LogKey) -> &'static str {
         LogKey::FamilyRuleFailed => "{family} {kind} rule creation failed: {error}",
         LogKey::FamilyRulesSkipped => "{family} {kind} skipped: {error}",
         LogKey::Ip6NatUnavailable => "ip6tables NAT unavailable, skip IPv6 {target}",
+        LogKey::Ipv6DnsFallbackApplied => {
+            "IPv6 DNS fallback applied: reject app {protocols} port 53 and use IPv4 core DNS"
+        }
         LogKey::CoreBypassFallback => "Core owner bypass failed, falling back to mark bypass",
         LogKey::PerformanceAddrtypeFallback => "{family} performance bypass: addrtype unavailable, using loopback fallback",
         LogKey::DnsCoreBypassFailed => "{target} core process bypass failed: owner match unavailable, DNS loopback may occur",
@@ -163,6 +166,9 @@ fn zh_template(key: LogKey) -> &'static str {
         LogKey::FamilyRuleFailed => "{family} {kind} 规则创建失败: {error}",
         LogKey::FamilyRulesSkipped => "{family} {kind} 已跳过: {error}",
         LogKey::Ip6NatUnavailable => "ip6tables NAT 不可用, 跳过 IPv6 {target}",
+        LogKey::Ipv6DnsFallbackApplied => {
+            "IPv6 DNS 回退已应用: 拒绝应用 {protocols} 53 端口并改用 IPv4 核心 DNS"
+        }
         LogKey::CoreBypassFallback => "核心 owner 绕过失败, 回退到 mark 绕过",
         LogKey::PerformanceAddrtypeFallback => "{family} 性能旁路: addrtype 不可用, 回退到显式回环",
         LogKey::DnsCoreBypassFailed => "{target} 核心进程绕过失败: owner 匹配不可用, 可能出现 DNS 回环",

--- a/boxctl/src/rules.rs
+++ b/boxctl/src/rules.rs
@@ -37,6 +37,7 @@ const TUN_BYPASS_PREF: &str = "98";
 const TUN_ROUTE_MARK: &str = "50331648/50331648";
 const TUN_ROUTE_TABLE: &str = "2025";
 const TUN_ROUTE_PREF: &str = "99";
+const IPV6_DNS_FALLBACK_CHAIN: &str = "BOX_DNS6_FALLBACK";
 const EBPF_PIN_DIR: &str = "/sys/fs/bpf/box";
 const EBPF_OUT4: &str = "/sys/fs/bpf/box/box_cidr_out4";
 const EBPF_OUT6: &str = "/sys/fs/bpf/box/box_cidr_out6";

--- a/boxctl/src/rules/cleanup.rs
+++ b/boxctl/src/rules/cleanup.rs
@@ -80,6 +80,7 @@ impl<'a> RuleManager<'a> {
             }
         }
         if family == Family::V6 {
+            self.cleanup_ipv6_dns_fallback();
             self.del_rule(
                 family,
                 "filter",

--- a/boxctl/src/rules/dns.rs
+++ b/boxctl/src/rules/dns.rs
@@ -47,7 +47,7 @@ impl<'a> RuleManager<'a> {
                 LogKey::Ip6NatUnavailable,
                 &[logger::nat_target_arg("target", "DNS redirect")],
             );
-            return Ok(());
+            return self.setup_ipv6_dns_fallback(context);
         }
 
         let kind = if self.dns_mode_is_redirect() {
@@ -56,6 +56,57 @@ impl<'a> RuleManager<'a> {
             DnsNatKind::Forward
         };
         self.setup_nat_dns_chain(family, kind, context)
+    }
+
+    pub(super) fn setup_ipv6_dns_fallback(&self, context: &RuleContext) -> Result<()> {
+        self.ensure_chain(Family::V6, "filter", IPV6_DNS_FALLBACK_CHAIN)?;
+        if !self.add_core_bypass_rule(Family::V6, "filter", IPV6_DNS_FALLBACK_CHAIN, "-A", context)
+        {
+            self.cleanup_ipv6_dns_fallback();
+            logger::warn_key(
+                self.config,
+                LogKey::DnsCoreBypassFailed,
+                &[logger::dns_nat_target_arg("target", "IPv6 fallback")],
+            );
+            return Ok(());
+        }
+
+        let mut protocols = Vec::new();
+        if self.dns_tcp_enabled() {
+            self.ensure_rule_append(
+                Family::V6,
+                "filter",
+                IPV6_DNS_FALLBACK_CHAIN,
+                &["-p", "tcp", "--dport", "53", "-j", "REJECT"],
+            )?;
+            protocols.push("TCP");
+        }
+        if self.dns_udp_enabled() {
+            self.ensure_rule_append(
+                Family::V6,
+                "filter",
+                IPV6_DNS_FALLBACK_CHAIN,
+                &["-p", "udp", "--dport", "53", "-j", "REJECT"],
+            )?;
+            protocols.push("UDP");
+        }
+        if protocols.is_empty() {
+            self.cleanup_ipv6_dns_fallback();
+            return Ok(());
+        }
+
+        self.ensure_jump(Family::V6, "filter", "OUTPUT", IPV6_DNS_FALLBACK_CHAIN)?;
+        logger::info_key(
+            self.config,
+            LogKey::Ipv6DnsFallbackApplied,
+            &[arg("protocols", protocols.join("/"))],
+        );
+        Ok(())
+    }
+
+    pub(super) fn cleanup_ipv6_dns_fallback(&self) {
+        self.del_jump(Family::V6, "filter", "OUTPUT", IPV6_DNS_FALLBACK_CHAIN);
+        self.cleanup_chain_fast(Family::V6, "filter", IPV6_DNS_FALLBACK_CHAIN);
     }
 
     pub(super) fn setup_nat_dns_chain(


### PR DESCRIPTION
修复部分 Android 设备不支持 IPv6 DNS 重定向时，应用绕过核心 DNS，导致网页无法打开或出现 SSL 错误的问题。现在会放行核心 DNS，并拒绝应用的 IPv6 53 端口请求，使系统回退到已接管的 IPv4 DNS。已通过实机验证。
